### PR TITLE
Fixed Package Preview Issue

### DIFF
--- a/kerckhoff/packages/operations/google_drive.py
+++ b/kerckhoff/packages/operations/google_drive.py
@@ -55,7 +55,7 @@ class GoogleDriveOperations:
         """
 
         payload = {
-            "q": f"'{gdrive_folder_id}' in parents",
+            "q": f"'{gdrive_folder_id}' in parents and trashed=false",
             "orderBy": "title",
             "maxResults": 100,
         }


### PR DESCRIPTION
The Google Drive API on Files:list is defaulted to show trashed files.
Hence, the fetch preview button would also list deleted files. This
commit is to fix the querying parameter to the API, and make sure that
trashed files will not be fetched.