### PR TITLE
Server side pull request implementing latest tasks.

### DIFF
--- a/kerckhoff/packages/operations/exceptions.py
+++ b/kerckhoff/packages/operations/exceptions.py
@@ -5,5 +5,13 @@ class OperationFailed(APIException):
     default_detail = "An operation has failed."
 
     def __init__(self, responseDict: dict):
-        if cause:
-            self.detail = f"An operation has failed, Cause: {str(responseDict)}"
+        #if cause: # commented out cause because it seems that it is causing an error
+        self.detail = f"An operation has failed, Cause: {str(responseDict)}"
+
+class GoogleDriveFileNotFound(APIException):
+    status_code = 400
+    default_detail = f"Google Drive folder not found, URL may be invalid."
+
+    def __init__(self, responseDict: dict):
+        #if cause: # commented out cause because it seems that it is causing an error
+        self.detail = f"Google Drive folder not found, URL may be invalid."

--- a/kerckhoff/packages/operations/google_drive.py
+++ b/kerckhoff/packages/operations/google_drive.py
@@ -6,7 +6,7 @@ from typing import Tuple, Optional, List
 from enum import Enum
 import logging
 
-from kerckhoff.packages.operations.exceptions import OperationFailed
+from kerckhoff.packages.operations.exceptions import OperationFailed, GoogleDriveFileNotFound
 from kerckhoff.packages.operations.models import GoogleDriveTextFile, GoogleDriveFile
 from kerckhoff.users.auth.google import GoogleOAuthStrategy
 
@@ -86,6 +86,14 @@ class GoogleDriveOperations:
                     break
 
             except RequestException:
+                error_msg = response.json()["error"]
+                error_code= error_msg["code"]
+
+                if error_code == 404:
+                    logger.error(
+                        f"File not found for id:{gdrive_folder_id} {response.json()}"
+                    )
+                    raise GoogleDriveFileNotFound(response.json()) 
                 logger.error(
                     f"Failed to list folder for id:{gdrive_folder_id} {response.json()}"
                 )


### PR DESCRIPTION
Provides correct feedback to the client when a invalid google drive URL is handed to the server.
* Will now raise a brand new exception GoogleDriveFileNotFound whenever the google drive API gives us a 404 in response to getting a folder.
* Small change to existing exception OperationFailed that fixed an error I kept receiving while testing. It was never given the cause, so I changed it so that it will always give the reason a operation failed now.